### PR TITLE
point package `main` and `style` fields to `build/` dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "ticketfly-css-grid-objects",
   "version": "0.0.2",
   "description": "Display utilities for Ticketfly CSS",
-  "main": "index.css",
-  "style": "index.css",
+  "main": "build/ticketfly-css-grid-objects.css",
+  "style": "build/ticketfly-css-grid-objects.css",
   "keywords": [
     "ticketfly-css",
     "ticketfly-css grid",


### PR DESCRIPTION
I'm thinking this is a direction that I want to move in with _all_ of our modules, but we should be able to [import things in our source CSS](https://github.com/Ticketfly-UI/ticketfly-css-grid-objects/blob/master/index.css#L5), and not have to worry about passing that dependency down to users. Pointing the `main` and `style` fields in `package.json` to the processed CSS in the `build/` directory will accomplish that.